### PR TITLE
Fix Dribbble portfolio integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Your Jekyll blog will often be viewable immediately at <http://username.github.i
 
 Enter your site name, description, avatar and many other options by editing the `_config.yml` file. You can easily turn on Google Analytics tracking, Disqus commenting and social icons here too.
 
-**Don't forget** to enter a Dribbble `Username` and `Client Access Token` to generate the portfolio ([Read more](https://github.com/tylergaw/jribbble#setting-your-apps-client-access-token)).
+**Don't forget** to enter a Dribbble `Client Access Token` (and optionally your `Username`) to generate the portfolio ([Read more](https://github.com/tylergaw/jribbble#setting-your-apps-client-access-token)).
 
 Making a change to `_config.yml` (or any file in your repository) will force GitHub Pages to rebuild your site with jekyll. Your rebuilt site will be viewable a few seconds later at <http://username.github.io> - if not, give it ten minutes as GitHub suggests and it'll appear soon
 

--- a/_config.yml
+++ b/_config.yml
@@ -42,7 +42,7 @@ google_analytics:
 # Used for Sitemap.xml and your RSS feed
 url:
 
-# Your Dribbble Username and Client Access Token
+# Your Dribbble Username (optional) and Client Access Token
 dribbble:
   username:
   token:

--- a/_includes/shots.html
+++ b/_includes/shots.html
@@ -1,21 +1,43 @@
 {% if site.dribbble.token %}
   {% include jribbble.html %}
   <script>
-    $.jribbble.setToken('{{ site.dribbble.token }}');
-    $.jribbble.users('{{ site.dribbble.username }}').shots({per_page: 62}).then(function(shots) {
-      var html = [];
+    (function () {
+      function renderShots(shots) {
+        var html = [];
 
-      shots.forEach(function(shot) {
-        html.push(
-          '<div class="shotsItem col-lg-3 col-md-4 col-sm-6">' +
-            '<a href="' + shot.html_url + '" target="_blank">' +
-              '<img src="' + shot.images.normal + '">' +
-            '</a>' +
-          '</div>'
-        );
-      });
+        if (Array.isArray(shots)) {
+          shots.forEach(function (shot) {
+            html.push(
+              '<div class="shotsItem col-lg-3 col-md-4 col-sm-6">' +
+                '<a href="' + shot.html_url + '" target="_blank">' +
+                  '<img src="' + shot.images.normal + '" alt="' + (shot.title || 'Dribbble shot') + '">' +
+                '</a>' +
+              '</div>'
+            );
+          });
+        }
 
-      $('.shots').html(html.join(''));
-    });
+        $('.shots').html(html.join(''));
+      }
+
+      function handleError(response) {
+        if (response && response.error) {
+          console.error('Dribbble API error:', response.error);
+        }
+      }
+
+      try {
+        jribbble.setToken('{{ site.dribbble.token }}');
+        jribbble.shots({ per_page: 62 }, function (response) {
+          if (Array.isArray(response)) {
+            renderShots(response);
+          } else {
+            handleError(response);
+          }
+        });
+      } catch (error) {
+        console.error('Unable to load Dribbble shots:', error);
+      }
+    })();
   </script>
 {% endif %}


### PR DESCRIPTION
## Summary
- update the Dribbble shots loader to use the current jribbble API
- add basic error handling and accessibility tweaks to the portfolio renderer
- document that the Dribbble username is optional when configuring the site

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e580076e688330982603e414dacd4d